### PR TITLE
Fix hostname generation + integer comparison compiler warning

### DIFF
--- a/WiFiSettings.cpp
+++ b/WiFiSettings.cpp
@@ -47,7 +47,7 @@ String pwgen() {
 }
 String html_entities(const String& raw) {
     String r;
-    for (int i = 0; i < raw.length(); i++) {
+    for (size_t i = 0; i < raw.length(); i++) {
         char c = raw.charAt(i);
         if (c >= '!' && c <= 'z' && c != '&' && c != '<' && c != '>') {
             // printable ascii minus html and {}
@@ -389,9 +389,9 @@ void WiFiSettingsClass::begin() {
 
 WiFiSettingsClass::WiFiSettingsClass() {
     #ifdef ESP32
-        hostname = Sprintf("esp32-%06" PRIx64, ESP.getEfuseMac() >> 24);
+        hostname = Sprintf("esp32-%06" PRIx64, ESP.getEfuseMac() & 0xFFFFFF);
     #else
-        hostname = Sprintf("esp8266-%06" PRIx32, ESP.getChipId() >> 8);
+        hostname = Sprintf("esp8266-%06" PRIx32, ESP.getChipId());
     #endif
 }
 

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "ESP-WiFiSettings",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "keywords": "esp32, esp8266, wifi",
     "description": "WiFi Manager for the ESP32 and ESP8266 Arduino environments", 
     "authors": [

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ESP-WiFiSettings
-version=3.0.0
+version=3.1.0
 author=Juerd Waalboer,Pwuts
 maintainer=Juerd Waalboer <#####@juerd.nl>
 sentence=WiFi configuration manager for the ESP32 and ESP8266 platforms.


### PR DESCRIPTION
## ESP32 hostname generation
**Problem:** currently, the hostname (if not set in the main sketch) is generated for the ESP32 from `ESP.getEfuseMac() >> 24`, which removes the last 24 bits of the MAC address, leaving the first 24 bits: the OUI (Organizationally Unique Identifier). This is the same for devices from the same manufacturer.
The unique part of the MAC address is the 24 bits that are currently discarded.

**Solution:** `ESP.getEfuseMac() & 0xFFFFFF` gives the *last* 24 bits.

## ESP8266 hostname generation
**Problem:** the hostname for the ESP8266 is generated using `ESP.getChipId() >> 8`, but since the chip ID of the ESP8266 is the last 24 bits of its MAC address, this only leaves 16 bits (AKA the first two symbols of the ID part of the hostname is aways `00`).

**Solution:** remove `>> 8` truncation.

## compiler warning
**Problem:** the compiler warned about a signed vs unsigned integer comparison. In the `for`-loop on [line 50 of `WiFiSettings.cpp`](https://github.com/Juerd/ESP-WiFiSettings/blob/05cbce279d546fada4c0e59678b9dce785118f20/WiFiSettings.cpp#L50), `int i` is used as an iterator but the limiter is `raw.length()` which has type `size_t`.

**Solution:** `for (size_t i = 0; i < raw.length(); i++)`

## version
I think fixing these bugs justifies a `v3.1.0` release, so I updated the version in the library manifests.