### PR TITLE
Allow for static IP options which reduce WiFi connection time.

### DIFF
--- a/WiFiSettings.cpp
+++ b/WiFiSettings.cpp
@@ -328,7 +328,7 @@ void WiFiSettingsClass::portal() {
     }
 }
 
-bool WiFiSettingsClass::connect(bool portal, int wait_seconds) {
+bool WiFiSettingsClass::connect(bool portal, int wait_seconds, IPAddress static_ip, IPAddress gateway, IPAddress subnet, IPAddress dns) {
     begin();
 
     WiFi.mode(WIFI_STA);
@@ -343,14 +343,14 @@ bool WiFiSettingsClass::connect(bool portal, int wait_seconds) {
     Serial.printf("Connecting to WiFi SSID '%s'", ssid.c_str());
     if (onConnect) onConnect();
 
-    WiFi.config(INADDR_NONE, INADDR_NONE, INADDR_NONE);  // arduino-esp32 #2537
+    WiFi.config(static_ip, gateway, subnet, dns);  // arduino-esp32 #2537
     WiFi.setHostname(hostname.c_str());
     WiFi.begin(ssid.c_str(), pw.c_str());
 
     unsigned long starttime = millis();
     while (WiFi.status() != WL_CONNECTED && (wait_seconds < 0 || (millis() - starttime) < wait_seconds * 1000)) {
         Serial.print(".");
-        delay(onWaitLoop ? onWaitLoop() : 100);
+        delay(onWaitLoop ? onWaitLoop() : 10);
     }
 
     if (WiFi.status() != WL_CONNECTED) {

--- a/WiFiSettings.h
+++ b/WiFiSettings.h
@@ -11,7 +11,7 @@ class WiFiSettingsClass {
 
         WiFiSettingsClass();
         void begin();
-        bool connect(bool portal = true, int wait_seconds = 30);
+        bool connect(bool portal = true, int wait_seconds = 30, IPAddress static_ip = INADDR_NONE, IPAddress gateway = INADDR_NONE, IPAddress subnet = INADDR_NONE, IPAddress dns = INADDR_NONE);
         void portal();
         String string(const String& name, const String& init = "", const String& label = "");
         String string(const String& name, unsigned int max_length, const String& init = "", const String& label = "");


### PR DESCRIPTION
For ESP32 devices, using a Static IP address can reduce the connection time (from 900 - 1000 ms to 500-600 ms).  

This change will give the user of this library the option to use Static IP if they are comfortable with that option (or to leave it as DHCP as the examples indicate).

