### PR TITLE
Handle unicode characters correctly

### DIFF
--- a/WiFiSettings.cpp
+++ b/WiFiSettings.cpp
@@ -65,7 +65,7 @@ namespace {  // Helpers
                 // printable non-whitespace ascii minus html and {}
                 r += c;
             } else {
-                r += Sprintf("&#%d;", raw.charAt(i));
+                r += raw.charAt(i);
             }
         }
         return r;
@@ -286,7 +286,7 @@ void WiFiSettingsClass::portal() {
 
         http.setContentLength(CONTENT_LENGTH_UNKNOWN);
         http.send(200, "text/html");
-        http.sendContent(F("<!DOCTYPE html>\n<meta charset=UTF-8><title>"));
+        http.sendContent(F("<!DOCTYPE html>\n<html><head><meta charset=UTF-8><title>"));
         http.sendContent(html_entities(hostname));
         http.sendContent(F("</title>"
             "<meta name=viewport content='width=device-width,initial-scale=1'>"
@@ -306,8 +306,8 @@ void WiFiSettingsClass::portal() {
             ".c{display:block;padding-left:2em}"
             ".w,.i{display:block;padding:.5ex .5ex .5ex 3em}"
             ".w,.i{background:#aaa;min-height:3em}"
-            "</style>"
-            "<form action=/restart method=post>"
+            "</style></head>"
+            "<body><form action=/restart method=post>"
         ));
         http.sendContent(F("<input type=submit value=\""));
         http.sendContent(_WSL_T.button_restart);
@@ -387,7 +387,7 @@ void WiFiSettingsClass::portal() {
             "<input type=submit value=\""
         ));
         http.sendContent(_WSL_T.button_save);
-        http.sendContent(F("\"style='font-size:150%'></form>"));
+        http.sendContent(F("\"style='font-size:150%'></form></body></html>"));
     });
 
     http.on("/", HTTP_POST, [this, &http]() {

--- a/WiFiSettings_strings.h
+++ b/WiFiSettings_strings.h
@@ -103,7 +103,7 @@ bool select(Texts& T, String& language) {
     }
 #endif
 
-#if defined LANGUAGE_EN || defined LANGUAGE_ALL
+#if defined LANGUAGE_DE || defined LANGUAGE_ALL
     if (language == "de") {
         T.title = F("Konfiguration");
         T.portal_wpa = F("Das Konfigurationsportal mit einem Passwort schützen");


### PR DESCRIPTION
I just noticed that unicode characters that are more than one byte long aren't properly displayed in the portal. After investigating the issue i found tha all characters are converted to single byte characters in the html_entities method. The call to Sprintf seems unneccesary to me and everything works fine so far.
Please note that I've only tested this on the ESP8266. I do not have an esp32 to test with.

I also corrected a mistake in the buildflags for the german language and made the html well formed.