### PR TITLE
Handle unicode characters in html entities

### DIFF
--- a/WiFiSettings.cpp
+++ b/WiFiSettings.cpp
@@ -61,8 +61,8 @@ namespace {  // Helpers
         String r;
         for (unsigned int i = 0; i < raw.length(); i++) {
             char c = raw.charAt(i);
-            if (c >= '!' && c <= 'z' && c != '&' && c != '<' && c != '>' && c != '\'' && c != '"') {
-                // printable non-whitespace ascii minus html and {}
+            if ((c >= '!' && c <= 'z' && c != '&' && c != '<' && c != '>' && c != '\'' && c != '"') || c >= 0x80) {
+                // printable non-whitespace ascii and unicode minus html and {}
                 r += c;
             } else {
                 r += Sprintf("&#%d;", raw.charAt(i));

--- a/WiFiSettings_strings.h
+++ b/WiFiSettings_strings.h
@@ -103,7 +103,7 @@ bool select(Texts& T, String& language) {
     }
 #endif
 
-#if defined LANGUAGE_EN || defined LANGUAGE_ALL
+#if defined LANGUAGE_DE || defined LANGUAGE_ALL
     if (language == "de") {
         T.title = F("Konfiguration");
         T.portal_wpa = F("Das Konfigurationsportal mit einem Passwort schützen");


### PR DESCRIPTION
Hi Juerd,

as promised i've created a new pullrequest for proper handeling of unicode characters.
I followed your approach of leaving everything above 0x7F unencoded. I've also tested some unicode specific control characters but they either break the string completely or show some other weired artifacts regardless of beeing encoded or not. I think these should be handled by the caller.

Let me know what you think.