### PR TITLE
fix for (or solve-direction suggestion) "filesystem not mounted" error

### DIFF
--- a/WiFiSettings.cpp
+++ b/WiFiSettings.cpp
@@ -1,8 +1,9 @@
 #include "WiFiSettings.h"
+
 #ifdef ESP32
-    #define ESPFS SPIFFS
+    #include <LittleFS.h>
+    #define ESPFS LittleFS
     #define ESPMAC (Sprintf("%06" PRIx64, ESP.getEfuseMac() >> 24))
-    #include <SPIFFS.h>
     #include <WiFi.h>
     #include <WebServer.h>
     #include <esp_task_wdt.h>
@@ -535,6 +536,8 @@ WiFiSettingsClass::WiFiSettingsClass() {
     #else
         hostname = F("esp8266-");
     #endif
+
+    ESPFS.begin();
 
     language = "en";
 }


### PR DESCRIPTION
It looks like that at least on an ESP32, including LittleFS.h (orSPIFFS.h) on two locations makes access to fail.

Thus: if you include it only in the WiFiSettings.cpp file and also
invoke the begin there, then it works fine: no more "[E][vfs_api.cpp:24]
open(): File system is not mounted" errors.