### PR TITLE
passwordify input, add option for littleFS backend on ESP32

### DIFF
--- a/WiFiSettings.cpp
+++ b/WiFiSettings.cpp
@@ -1,8 +1,14 @@
 #include "WiFiSettings.h"
 #ifdef ESP32
-    #define ESPFS SPIFFS
     #define ESPMAC (Sprintf("%06" PRIx64, ESP.getEfuseMac() >> 24))
-    #include <SPIFFS.h>
+    
+    #ifdef WIFISETTINGS_USE_LITTLEFS
+        #define ESPFS LittleFS
+        #include <LittleFS.h>
+    #else
+        #define ESPFS SPIFFS
+        #include <SPIFFS.h>
+    #endif
     #include <WiFi.h>
     #include <WebServer.h>
     #include <esp_task_wdt.h>
@@ -359,7 +365,7 @@ void WiFiSettingsClass::portal() {
         http.sendContent(F("</a><p><label>"));
 
         http.sendContent(_WSL_T.wifi_password);
-        http.sendContent(F(":<br><input name=password value='"));
+        http.sendContent(F(":<br><input type=\"password\" name=password value='"));
         if (slurp("/wifi-password").length()) http.sendContent("##**##**##**");
         http.sendContent(F("'></label><hr>"));
 


### PR DESCRIPTION
This solves the problem from https://github.com/Juerd/ESP-WiFiSettings/issues/31

On platformio you can config it by adding
``` 
build_flags = 
    -DWIFISETTINGS_USE_LITTLEFS
```

Also, I set `password` input field to `type="password"` because on my android, when typing a random string into a normal input field, the string is automatically added to future autocompletions, which is undesirable.