### PR TITLE
Adding custom and masked password fields in the AP Config page for custom password variables - Solution to issue #33

### DIFF
--- a/WiFiSettings.h
+++ b/WiFiSettings.h
@@ -17,6 +17,7 @@ class WiFiSettingsClass {
         String string(const String& name, const String& init = "", const String& label = "");
         String string(const String& name, unsigned int max_length, const String& init = "", const String& label = "");
         String string(const String& name, unsigned int min_length, unsigned int max_length, const String& init = "", const String& label = "");
+        String passwordstring(const String& name, const String& init = "", const String& label = "");
         long integer(const String& name, long init = 0, const String& label = "");
         long integer(const String& name, long min, long max, long init = 0, const String& label = "");
         bool checkbox(const String& name, bool init = false, const String& label = "");


### PR DESCRIPTION
This pull request solves issue #33. 

-Adds a new WiFiSettingsClass::passwordstring and WiFiSettingsPasswordString struct that is are copies of WiFiSettingsClass::string and WiFiSettingsString struct but has the html value hardcoded to the value `##**##**##**` and the value is not updated by the new value entered.

-for loop at line 410 checks the args if the custom password field already has the mask `##**##**##**` so that it only stores a new value if the value has been changed from the mask `##**##**##**` 